### PR TITLE
install imandra-starter-template as an iml library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ run:
 clean:
 	opam exec -- dune clean
 
+install-iml:
+	opam exec --switch=$(IMANDRA_SWITCH) -- dune build @install
+	opam exec --switch=$(IMANDRA_SWITCH) -- dune install
+
 .PHONY: test
 test:
 	opam exec --switch=$(IMANDRA_SWITCH) -- dune runtest test-vgs/

--- a/imandra-starter-template.opam
+++ b/imandra-starter-template.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+name: "imandra-starter-template"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/src-iml/dune
+++ b/src-iml/dune
@@ -1,7 +1,16 @@
 ;; This dune file makes the IML model code available to our OCaml program as a library.
 
 (library
- (name model)
+ (name imandra_starter_template_iml)
+ (public_name imandra-starter-template)
+ (modules \ gauss))
+
+(install
+ (section lib)
+ (files imandra-starter-template.iml imandra_starter_template.iml gauss.iml))
+
+(library
+ (name imandra_starter_template)
  (libraries imandra-prelude))
 
 ;; Use imandra-extract to general ml files from iml.

--- a/src-iml/imandra-starter-template.iml
+++ b/src-iml/imandra-starter-template.iml
@@ -1,0 +1,1 @@
+[@@@import "imandra_starter_template.iml"]

--- a/src-iml/imandra_starter_template.iml
+++ b/src-iml/imandra_starter_template.iml
@@ -2,9 +2,11 @@
 
     To use it, cd into this directory, run `imandra-repl` and enter at the prompt:
 
-    # #use "load.iml";;
+    # #mod_use "imandra_standard_template.iml";;
 *)
 
 
 (* List all model files here, in dependency order. *)
-#mod_use "./gauss.iml";;
+[@@@import "gauss.iml"]
+
+module Gauss = Gauss

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name my_program)
- (libraries model))
+ (libraries imandra_starter_template))

--- a/src-ocaml/main.ml
+++ b/src-ocaml/main.ml
@@ -3,4 +3,4 @@ let () =
   let n = Scanf.scanf "%d" (fun x -> x) in
   Format.printf "@.The sum of the integers from 1 to %d is %a@."
     n
-    Z.pp_print (Model.Gauss.sum_integers_up_to (Z.of_int n))
+    Z.pp_print (Imandra_starter_template.Gauss.sum_integers_up_to (Z.of_int n))

--- a/test-vgs/dune
+++ b/test-vgs/dune
@@ -1,6 +1,6 @@
 (test
  (name main)
  (modes byte)
- (libraries imandra-client.lib model alcotest)
+ (libraries imandra-client.lib imandra_starter_template alcotest)
  (deps
   (glob_files ../src-iml/*.iml)))

--- a/test-vgs/main.ml
+++ b/test-vgs/main.ml
@@ -17,7 +17,7 @@ let tests =
     , [ verify_test_case
           ~name:"Gauss' theorem holds"
           ~hints:Hints.auto
-          "Gauss.gauss_theorem"
+          "Imandra_starter_template.Gauss.gauss_theorem"
       ]
     )
   ]
@@ -26,6 +26,6 @@ let () =
   Client.with_server ~server_name:"imandra_network_client" (fun () ->
       Tlcontext.update_exec_level NO_INTERP;
       Imandra.do_init ~linenoise:false ();
-      System.add_path "../src-iml";
-      System.use ~quiet:true "load.iml";
+      System.add_path "../src-iml/";
+      System.mod_use ~quiet:true "imandra_starter_template.iml";
       Alcotest.run "Verification Goals" tests)


### PR DESCRIPTION
Needs to wait for `imandra` to fix its handling of `../` in import