### PR TITLE
Python bindings to the `imandra-extract`ed OCaml code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .imandra_init.log
 .merlin
 /*.install
+__pycache__/
+main_python.so

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build test
 _opam:
 	opam switch create . --empty
 	opam install -y ocaml-base-compiler.4.12.1
-	opam switch set-base ocaml-base-compiler.4.12.1
+	opam switch set-invariant ocaml-base-compiler.4.12.1
 	opam repo add imandra https://github.com/AestheticIntegration/opam-repository.git
 
 setup: _opam

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Enter a positive integer: 55
 The sum of the integers from 1 to 55 is 1540
 ```
 
+## Python bindings 
+Upon each `make build`, verify that a `main_python.so` shared object file is created within the `src-python/wrapper` 
+directory. This shared object file can be used to import as a python module. To do this, first add the python module to your
+Python PATH. Then, running the `test.py` file should then call the extracted OCaml function from within Python. 
+
+
 ## Verification goals
 
 ```

--- a/dune-project
+++ b/dune-project
@@ -1,8 +1,8 @@
-(lang dune 2.9)
+(lang dune 1.11)
 
 (name imandra-starter-template)
 
-; (using fmt 1.2)
+(using fmt 1.2)
 
 ;; Use imandra-extract to generate ml files from iml.
 

--- a/dune-project
+++ b/dune-project
@@ -1,12 +1,18 @@
-(lang dune 1.11)
+(lang dune 2.9)
+
 (name imandra-starter-template)
-(using fmt 1.2)
+
+; (using fmt 1.2)
 
 ;; Use imandra-extract to generate ml files from iml.
+
 (dialect
  (name imandra)
  (implementation
   (extension "iml")
-  (preprocess (run imandra-extract %{input-file}))
-  (format (run ocamlformat %{input-file})))
- (interface (extension "imli")))
+  (preprocess
+   (run imandra-extract %{input-file}))
+  (format
+   (run ocamlformat %{input-file})))
+ (interface
+  (extension "imli")))

--- a/dune-project
+++ b/dune-project
@@ -1,8 +1,8 @@
-(lang dune 1.11)
+(lang dune 2.9)
 
 (name imandra-starter-template)
 
-(using fmt 1.2)
+; (using fmt 1.2)
 
 ;; Use imandra-extract to generate ml files from iml.
 

--- a/src-iml/dune
+++ b/src-iml/dune
@@ -2,5 +2,6 @@
 
 (library
  (name model)
+ (public_name imandra-starter-template.model)
  (libraries imandra-prelude)
  (flags :standard -warn-error -33))

--- a/src-ocaml/bindings.ml
+++ b/src-ocaml/bindings.ml
@@ -1,0 +1,5 @@
+open Python_lib
+open Python_lib.Let_syntax
+let py_gauss = 
+  let%map_open n = keyword "n" int ~docstring:"" 
+in fun () -> Model.Gauss.sum_integers_up_to (Z.of_int n) |> Z.to_int |> python_of_int

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -23,6 +23,6 @@
   pythonlib)
  (promote
   (until-clean)
-  (into "../src-python/wrapper/")
+  (into "../src-python/wrapper")
   (only *.so))
  (modules main_python))

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -17,7 +17,10 @@
  ; (public_name foo)
  (modes
   (native shared_object))
- (libraries imandra-starter-template.model pythonlib)
+ (libraries
+  imandra-starter-template.python_bindings
+  imandra-starter-template.model
+  pythonlib)
  (promote
   (until-clean)
   (into "wrapper/")

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -23,6 +23,6 @@
   pythonlib)
  (promote
   (until-clean)
-  (into "wrapper/")
+  (into "../src-python/wrapper/")
   (only *.so))
  (modules main_python))

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -1,4 +1,25 @@
+(library
+ (name python_bindings)
+ (preprocess
+  (pps ppx_let))
+ (public_name imandra-starter-template.python_bindings)
+ (modules bindings)
+ (libraries imandra-starter-template.model pythonlib))
+
 (executable
  (name main)
+ (modules main)
  (public_name my_program)
- (libraries model))
+ (libraries imandra-starter-template.model))
+
+(executable
+ (name main_python)
+ ; (public_name foo)
+ (modes
+  (native shared_object))
+ (libraries imandra-starter-template.model pythonlib)
+ (promote
+  (until-clean)
+  (into "wrapper/")
+  (only *.so))
+ (modules main_python))

--- a/src-ocaml/main_python.ml
+++ b/src-ocaml/main_python.ml
@@ -1,0 +1,6 @@
+open Python_lib 
+
+let () =
+  if not (Py.is_initialized ()) then Py.initialize ();
+  let mod_ = Py_module.create "enx_wrapper" in
+  Py_module.set mod_ "run_sim" Bindings.py_run_sim;

--- a/src-ocaml/main_python.ml
+++ b/src-ocaml/main_python.ml
@@ -3,4 +3,4 @@ open Python_lib
 let () =
   if not (Py.is_initialized ()) then Py.initialize ();
   let mod_ = Py_module.create "enx_wrapper" in
-  Py_module.set mod_ "run_sim" Bindings.py_run_sim;
+  Py_module.set mod_ "run_sim" Python_bindings.Bindings.py_gauss;

--- a/src-ocaml/main_python.ml
+++ b/src-ocaml/main_python.ml
@@ -2,5 +2,5 @@ open Python_lib
 
 let () =
   if not (Py.is_initialized ()) then Py.initialize ();
-  let mod_ = Py_module.create "enx_wrapper" in
-  Py_module.set mod_ "run_sim" Python_bindings.Bindings.py_gauss;
+  let mod_ = Py_module.create "python_gauss" in
+  Py_module.set mod_ "gauss" Python_bindings.Bindings.py_gauss;

--- a/src-python/test.py
+++ b/src-python/test.py
@@ -1,0 +1,8 @@
+import sys
+
+sys.path.insert(0, "./src-python/wrapper")
+
+from wrapper import *
+
+if __name__ == "__main__":
+    print(gauss(n=100))

--- a/src-python/wrapper/__init__.py
+++ b/src-python/wrapper/__init__.py
@@ -1,0 +1,15 @@
+"""
+An example Ocaml library exposed to Python
+"""
+
+import os
+from ctypes import PyDLL, RTLD_GLOBAL, c_char_p
+
+curdir = os.path.dirname(os.path.realpath(__file__))
+dll = PyDLL(f"{curdir}/main_python.so", RTLD_GLOBAL)
+argv_t = c_char_p * 2
+argv = argv_t("main_python.so".encode("utf-8"), None)
+dll.caml_startup(argv)
+
+# We export the names explicitly otherwise mypy
+from python_gauss import *

--- a/test-vgs/main.ml
+++ b/test-vgs/main.ml
@@ -1,45 +1,53 @@
 open Imandra_client_lib
 
 let quiet = false
+
 let has_error () = History.State.(error_seen () || exn_seen ())
 
 let init () =
-  Tlcontext.(update_exec_level NO_INTERP);
-  Imandra.do_init ~linenoise:false ();
-  Debug.setup_logs_reporter ();
-  Imandra_util_frontend.Debug_frontend.set_debug_backend_stdout ();
+  Tlcontext.(update_exec_level NO_INTERP) ;
+  Imandra.do_init ~linenoise:false () ;
+  Debug.setup_logs_reporter () ;
+  Imandra_util_frontend.Debug_frontend.set_debug_backend_stdout () ;
 
-  CCFormat.printf "Loading model...@.";
+  CCFormat.printf "Loading model...@." ;
   let () =
     [ "gauss_vgs" ]
     |> CCList.iter (fun file ->
-           if not (has_error ()) then
+           if not (has_error ())
+           then
              let () = Printf.printf "Loading %s.iml\n" file in
              let _ =
                Imandra.eval_string
                @@ CCFormat.sprintf {| #use "%s.iml";; |} file
              in
-             ())
+             () )
   in
   ()
 
+
 let run_tests () =
-  if not (has_error ()) then (
-    CCFormat.printf "Closing goals...@.";
+  if not (has_error ())
+  then (
+    CCFormat.printf "Closing goals...@." ;
     System.eval
       {| [@@@require "imandra-goals-alcotest"];;
 
        Imandra_goals_alcotest.run_tests ~report_name:"gauss" ()
-     |})
+     |}
+    )
+
 
 let main () =
   try
-    init ();
+    init () ;
     run_tests ()
-  with e ->
-    History.State.record_exn_seen ();
-    let bt = Printexc.get_raw_backtrace () in
-    CCFormat.eprintf "%a" (Imandra_syntax.Util_err.pp_exn ~bt ?input:None) e
+  with
+  | e ->
+      History.State.record_exn_seen () ;
+      let bt = Printexc.get_raw_backtrace () in
+      CCFormat.eprintf "%a" (Imandra_syntax.Util_err.pp_exn ~bt ?input:None) e
+
 
 let do_exit () = if has_error () then exit 1 else exit 0
 
@@ -48,9 +56,9 @@ let () =
     Sys.getenv_opt "IMANDRA_SERVER"
     |> CCOption.get_lazy (fun () ->
            let default = "imandra_network_client" in
-           CCFormat.eprintf "IMANDRA_SERVER not set; using %S" default;
-           default)
+           CCFormat.eprintf "IMANDRA_SERVER not set; using %S" default ;
+           default )
   in
-  CCFormat.printf "Connecting to Imandra server...@.";
-  Client.with_server ~server_name ~socket_dir:"/tmp" (fun ~stop:_stop -> main);
+  CCFormat.printf "Connecting to Imandra server...@." ;
+  Client.with_server ~server_name ~socket_dir:"/tmp" (fun ~stop:_stop -> main) ;
   do_exit ()


### PR DESCRIPTION
This PR adds a prototype implementation of python bindings to the generated `gauss` function. 

`make build` should  `promote` a `main_python.so` file into `src-python/wrapper` directory. This `wrapper` module should be added to the Python PATH, upon which running the `test.py` in that directory should call the OCaml function from within Python. On my machine I do this by running the `__init__.py` file within that directory. 

Note: I needed to update the `dune` version to 2.9 for the `promote` stanza to work. 

